### PR TITLE
Bump backend version

### DIFF
--- a/plugins/security-backend/package.json
+++ b/plugins/security-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@RedHatInsights/backstage-plugin-security-backend",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This just bumps the version of our backend plugin to match the frontend version. `0.1.3``